### PR TITLE
Support use of pipenv

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+requests = "*"
+
+[requires]
+python_version = "3.6"


### PR DESCRIPTION
It is nice to support pipenv so user just needs to 
`pipenv install` and don't have to mess up with their global env